### PR TITLE
Change env name to match azure standards

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -3,8 +3,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-GOOGLE_MAPS_API_KEY = os.getenv("GOOGLEMAPAPIKEY")
+GOOGLE_MAPS_API_KEY = os.getenv("GOOGLEMAPSAPIKEY")
 
 if not GOOGLE_MAPS_API_KEY:
     raise ValueError("GOOGLE_MAPS_API_KEY is missing or not loaded correctly")
-


### PR DESCRIPTION
This pull request includes a small change to the `app/config/settings.py` file. The change ensures that the `GOOGLE_MAPS_API_KEY` environment variable is properly retrieved using `os.getenv`. 

* [`app/config/settings.py`](diffhunk://#diff-b855bb64e5796dfbc5e1297b782bc0e3542252a82e7622120fff29913e099d45L6-L10): Corrected the retrieval of the `GOOGLE_MAPS_API_KEY` environment variable to ensure it is loaded correctly.