### PR TITLE
Fix env in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,8 +2,6 @@ services:
   maps-wrapper:
     build: .
     container_name: maps-wrapper
-    env_file:
-      - .env
     environment:
       - REDIS_HOST=maps_wrapper_cache
       - REDIS_PORT=6379


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.yaml` file. The change removes the `env_file` configuration for the `maps-wrapper` service, which previously loaded environment variables from the `.env` file.

Configuration changes:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L5-L6): Removed the `env_file` configuration for the `maps-wrapper` service.